### PR TITLE
ExternalId as payment reference.

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,54 @@
-_site
-.sass-cache
+### Jekyll ###
+_site/
+.sass-cache/
+.jekyll-cache/
 .jekyll-metadata
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -257,7 +257,7 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.1.4

--- a/docs/oneoffs.md
+++ b/docs/oneoffs.md
@@ -62,8 +62,15 @@ Add a `one_off_payment` property to the `POST /api/providers/{providerId}/agreem
 |**one_off_payment**              |object      |          |*__One-Off Payment__ details.*||
 |**one_off_payment.amount**       |number(0.00)|required  |*__One-Off Payment__ amount, which will be displayed for the user in the MobilePay app.*|> 0.00, decimals separated with a dot.|
 |**one_off_payment.description**  |string(60)  |required  |*Additional information provided by the merchant to the user, that will be displayed on the __One-off Payment__ screen.*||
-|**one_off_payment.external_id**  |string(30)  |required  |*__One-Off Payment__ identifier on the merchant's side. This will be included in the request body of the payment callback.*||
+|**one_off_payment.external_id**  |string(64)*  |required  |*__One-Off Payment__ identifier on the merchant's side. This will be included in the request body of the payment callback.*||
 |**one_off_payment.expiration_timeout_minutes**|int|optional|*__One-Off Payment__ expiration timeout in minutes.*|Min: 1, max: 20160 (2 weeks), default: 1440 (24 hours)|
+
+<div class="note">
+    <strong>Note:</strong>
+    <p>
+        * Recommendation for "external_id" is to use up to 30 symbols. For instant transfers "external_id" is used as payment reference and will be truncated down to 30 symbols if it contains more. Truncated payment reference will be visible in bank statement.
+    </p>
+</div>
 
 <a name="oneoffpayments_response-new"></a>In this case the response of `POST /api/providers/{providerId}/agreements` will contain additional `one_off_payment_id` value - id of the newly requested **One-Off Payment**.
 

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -57,9 +57,16 @@ Agreement disable_notification_management push notification. Merchant can set if
 |**amount**            |number(0.00)| required |*The requested amount to be paid.*|> 0.00, decimals separated with a dot.|
 |**due_date**          |date        | required |*Payment due date. Must be at least 1 day in the future, otherwise the __Subscription Payment__ will be declined.*|ISO date format: yyyy-MM-dd|
 |**next_payment_date** |date        |          |*Next __Subscription Payment's__ due date, to be shown to the user in the __Agreement__ details.*|ISO date format: yyyy-MM-dd|
-|**external_id**       |string(64)      | required |*The identifier of a specific payment in the external merchant's system. Maximum length is 64 characters*||
+|**external_id**       |string(64)*      | required |*The identifier of a specific payment in the external merchant's system. Maximum length is 64 characters*||
 |**description**       |string(60)  | required |*Additional information of the __Subscription Payment__.*||
 |**grace_period_days** |int  | optional |*Number of days to keep retrying the payment if it was not successful.*|1, 2, 3|
+
+<div class="note">
+    <strong>Note:</strong>
+    <p>
+        * Recommendation for "external_id" is to use up to 30 symbols. For instant transfers "external_id" is used as payment reference and will be truncated down to 30 symbols if it contains more. Truncated payment reference will be visible in bank statement.
+    </p>
+</div>
 
 <a name="subscription-payments_response"></a>
 The `POST /api/providers/{providerId}/paymentrequests` service returns HTTP 202 - Accepted response if at least one payment is provided in the request payload.


### PR DESCRIPTION
Truncation in bank statement if it contains more than 30 symbols