### PR TITLE
Updated with correct pattern for given datetime

### DIFF
--- a/docs/agreement.md
+++ b/docs/agreement.md
@@ -184,7 +184,7 @@ You do not get a callback that tells you specifically if/when the user closes th
 |----------------|------------|------------------------------------------------------|------|
 |**agreement_id**|guid        |Subscription agreement ID on the MobilePay side.||
 |**external_id** |string      |Agreement ID on the merchant's side                   ||
-|**timestamp**   |datetime    |Timestamp when the status change occurred.            |ISO 8601 UTC date and time format: YYYY-MM-DDThh:mm:ssZ|
+|**timestamp**   |datetime    |Timestamp when the status change occurred.            |ISO 8601 UTC date and time format: YYYY-MM-DDThh:mm:ssXXX|
 
 ##### <a name="agreements_callback-request"></a>Agreement callback request example
 


### PR DESCRIPTION
The current pattern for datetime: YYYY-MM-DDThh:mm:ssZ, only works for datetime that is like this example: 2020-01-01T12:34:56+0000 and not for 2020-01-01T12:34:56+00:00
The pattern should be like this YYYY-MM-DDThh:mm:ssXXX